### PR TITLE
Fix animationend event handler bug

### DIFF
--- a/js/scripts.js
+++ b/js/scripts.js
@@ -136,11 +136,16 @@
                 //to show index of img in list
                 var index = that.current + 1;
                 // startImg.find('.img-index').html(index + ' sur ' + that.count);
+                var animationendHandlers = 'webkitAnimationEnd oanimationend msAnimationEnd animationend';
 
-                $this.one('webkitAnimationEnd oanimationend msAnimationEnd animationend', function(e) {
+                $this.one(animationendHandlers, function(e) {
                     startImg.addClass('fadeInScaleUp').removeClass('fadeOut');
                     that.bigItemsList.css('pointer-events', 'auto');
                     that.changeHeight(600);
+
+                    //unbind all event handlers to prevent prefixed handlers from firing
+                    //in browsers that support the animation property without a prefix
+                    $(this).off(animationendHandlers);
                 });   
             });
         },


### PR DESCRIPTION
The selected image animates back in after quitting the slideshow in browsers that support the animation property and a vendor-prefixed version of the property. The animationend handler fires after clicking on a list item, and the webkitAnimationEnd handler fires after quitting the slideshow.

![animationend-bug](https://cloud.githubusercontent.com/assets/5439242/11707523/a24f0870-9ed3-11e5-958e-22c8835abeaf.jpg)
